### PR TITLE
fix: disable dynamiqs progress meter to prevent ZMQError in Jupyter

### DIFF
--- a/src/oqd_trical/backend/dynamiqs/base.py
+++ b/src/oqd_trical/backend/dynamiqs/base.py
@@ -37,7 +37,13 @@ class DynamiqsBackend(BackendBase):
         save_intermediate (bool): Whether compiler saves the intermediate representation of the atomic circuit
         approx_pass (PassBase): Pass of approximations to apply to the system.
         solver (Literal["SESolver","MESolver"]): Dynamiqs solver to use.
-        solver_options (Dict[str,Any]): Dynamiqs solver options
+        solver_options (Dict[str,Any]): Options forwarded to the dynamiqs VM.
+            Recognised keys:
+
+            - ``"solver"``: integration method (e.g. ``dq.Tsit5()``).
+            - ``"progress_meter"``: ``False`` / ``True`` / an
+              ``AbstractProgressMeter``. Defaults to ``NoProgressMeter()``
+              (silent) to prevent ZMQ file-descriptor exhaustion in Jupyter.
         intermediate (AtomicEmulatorCircuit): Intermediate representation of the atomic circuit during compilation
     """
 

--- a/src/oqd_trical/backend/dynamiqs/vm.py
+++ b/src/oqd_trical/backend/dynamiqs/vm.py
@@ -14,8 +14,13 @@
 
 import dynamiqs as dq
 from dynamiqs import mesolve, sesolve
+from dynamiqs.progress_meter import NoProgressMeter
 from jax import numpy as jnp
 from oqd_compiler_infrastructure import RewriteRule
+
+# dynamiqs 0.3.1 named the integration method parameter 'solver'; 0.3.2 renamed it
+# to 'method'. Detect which name to use at import time so calls stay compatible.
+_METHOD_KWARG = "solver" if hasattr(dq, "solver") else "method"
 
 ########################################################################################
 
@@ -28,7 +33,13 @@ class DynamiqsVM(RewriteRule):
         hilbert_space (Dict[str, int]): Hilbert space of the system.
         timestep (float): Timestep between tracked states of the evolution.
         solver (Literal["SESolver","MESolver"]): Dynamiqs solver to use.
-        solver_options (Dict[str,Any]): Dynamiqs solver options
+        solver_options (Dict[str,Any]): Dynamiqs solver options. Recognised keys:
+            - ``"solver"``: integration method passed to sesolve/mesolve (e.g.
+              ``dq.Tsit5()``). Defaults to the dynamiqs built-in default.
+            - ``"progress_meter"``: ``False`` / ``True`` / an
+              ``AbstractProgressMeter`` instance. Defaults to
+              ``NoProgressMeter()`` (no output) to avoid exhausting file
+              descriptors when the backend is called from Jupyter/ipykernel.
     """
 
     def __init__(
@@ -92,13 +103,20 @@ class DynamiqsVM(RewriteRule):
             self.states.extend([self.current_state] * (len(tspan) - 1))
             return
 
+        solver_kwargs = {}
+        if "solver" in self.solver_options:
+            solver_kwargs[_METHOD_KWARG] = self.solver_options["solver"]
+
+        options = dq.Options(
+            progress_meter=self.solver_options.get("progress_meter", NoProgressMeter())
+        )
+
         res = self.solver(
             model.hamiltonian,
             self.current_state,
             tspan,
-            solver=self.solver_options["solver"]
-            if "solver" in self.solver_options.keys()
-            else dq.solver.Tsit5(),
+            **solver_kwargs,
+            options=options,
         )
 
         self.current_state = res.final_state


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fix 

* **What is the current behavior?** (You can also link to an open issue here)
Closes #26 

Running DynamiqsBackend from a Jupyter notebook crashes with `ZMQError: Too many open files`. The diffrax progress meter fires a JAX callback on every ODE step which writes to stdout. In ipykernel each write on a background thread creates a new ZMQ socket instead of reusing one, and after enough steps the OS fd limit is hit. There is also a crash on dynamiqs >= 0.3.2 where `dq.solver` was renamed to `dq.method`, so the old default call raises `AttributeError`

* **What is the new behavior (if this is a feature change)?**
`NoProgressMeter` is passed to every `sesolve`/`mesolve` call by default so no sockets are created. Users who want the progress bar can pass `solver_options={"progress_meter": True}`. The solver kwarg name is detected at import time so both dynamiqs 0.3.1 and 0.3.2 work without a version check.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:

Without the fix:

  ```python
  import dynamiqs as dq
  import jax.numpy as jnp

  H = dq.sigmax()
  psi0 = dq.basis(2, 0)
  tsave = jnp.linspace(0, 1e-6, 50)
  dq.sesolve(H, psi0, tsave)
  ```
  
```bash
  |          |   0.0% elapsed 0.00ms remaining ?
  |██████████| 100.0% elapsed 0.53ms remaining 0.00ms
```

Each of those steps creates a new ZMQ socket in Jupyter until the process runs out of file descriptors. After the fix the same code runs silent.
