### PR TITLE
Fix Dynamiqs backend for AtomicCircuit simulation (#43)

### DIFF
--- a/docs/explanation/backends.md
+++ b/docs/explanation/backends.md
@@ -5,7 +5,7 @@ Backends are used to execute the AtomicCircuit.
 ## Supported Backends
 
 - [QuTiP](https://qutip.readthedocs.io/en/latest/) <div style="float:right;"> [![](https://img.shields.io/badge/Implementation-7C4DFF)][oqd_trical.backend.qutip.QutipBackend] </div>
-- [Dynamiqs](https://qutip.readthedocs.io/en/latest/) <div style="float:right;"> [![](https://img.shields.io/badge/Implementation-7C4DFF)][oqd_trical.backend.dynamiqs.DynamiqsBackend] </div>
+- [Dynamiqs](https://www.dynamiqs.org/) <div style="float:right;"> [![](https://img.shields.io/badge/Implementation-7C4DFF)][oqd_trical.backend.dynamiqs.DynamiqsBackend] </div>
 
 ## Compile
 
@@ -32,3 +32,7 @@ Executes the compatible form of the AtomicCircuit with the backend using a tree 
 - Dynamiqs uses [`DynamiqsVM`][oqd_trical.backend.dynamiqs.vm.DynamiqsVM] as its tree walking interpreter.
 
 ///
+
+## Dynamiqs units and solver options
+
+Energies, Rabi frequencies, and detunings are in **rad/s**; pulse durations are in **seconds**. Configure Diffrax integration via [`DynamiqsSolverOptions`][oqd_trical.backend.dynamiqs.solver.DynamiqsSolverOptions] on [`DynamiqsBackend`][oqd_trical.backend.dynamiqs.DynamiqsBackend] (see `solver.py` for defaults).

--- a/src/oqd_trical/backend/__init__.py
+++ b/src/oqd_trical/backend/__init__.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 from . import dynamiqs, qutip
-from .dynamiqs import DynamiqsBackend
+from .dynamiqs import DynamiqsBackend, DynamiqsSolverOptions, TaskArgsAtomicEmulator
 from .qutip import QutipBackend
 
 __all__ = [
     "qutip",
     "dynamiqs",
     "DynamiqsBackend",
+    "DynamiqsSolverOptions",
+    "TaskArgsAtomicEmulator",
     "QutipBackend",
 ]

--- a/src/oqd_trical/backend/dynamiqs/__init__.py
+++ b/src/oqd_trical/backend/dynamiqs/__init__.py
@@ -14,10 +14,14 @@
 
 from .base import DynamiqsBackend
 from .codegen import DynamiqsCodeGeneration
+from .solver import DynamiqsSolverOptions
+from .task import TaskArgsAtomicEmulator
 from .vm import DynamiqsVM
 
 __all__ = [
     "DynamiqsBackend",
     "DynamiqsCodeGeneration",
+    "DynamiqsSolverOptions",
+    "TaskArgsAtomicEmulator",
     "DynamiqsVM",
 ]

--- a/src/oqd_trical/backend/dynamiqs/base.py
+++ b/src/oqd_trical/backend/dynamiqs/base.py
@@ -14,10 +14,18 @@
 
 from oqd_compiler_infrastructure import Chain, Post, Pre
 from oqd_core.backend.base import BackendBase
+from oqd_core.backend.task import Task, TaskArgsAtomic
 from oqd_core.compiler.atomic.canonicalize import canonicalize_atomic_circuit_factory
 from oqd_core.interface.atomic import AtomicCircuit
 
 from oqd_trical.backend.dynamiqs.codegen import DynamiqsCodeGeneration
+from oqd_trical.backend.dynamiqs.solver import (
+    normalize_solver_options,
+)
+from oqd_trical.backend.dynamiqs.task import (
+    TaskArgsAtomicEmulator,
+    task_args_from_atomic,
+)
 from oqd_trical.backend.dynamiqs.vm import DynamiqsVM
 from oqd_trical.light_matter.compiler.analysis import GetHilbertSpace, HilbertSpace
 from oqd_trical.light_matter.compiler.canonicalize import (
@@ -37,7 +45,9 @@ class DynamiqsBackend(BackendBase):
         save_intermediate (bool): Whether compiler saves the intermediate representation of the atomic circuit
         approx_pass (PassBase): Pass of approximations to apply to the system.
         solver (Literal["SESolver","MESolver"]): Dynamiqs solver to use.
-        solver_options (Dict[str,Any]): Dynamiqs solver options
+        solver_options (Union[DynamiqsSolverOptions, Dict[str, Any]]): Diffrax method and
+            tolerances passed to ``dq.sesolve``; see
+            [`DynamiqsSolverOptions`][oqd_trical.backend.dynamiqs.solver.DynamiqsSolverOptions].
         intermediate (AtomicEmulatorCircuit): Intermediate representation of the atomic circuit during compilation
     """
 
@@ -46,7 +56,7 @@ class DynamiqsBackend(BackendBase):
         save_intermediate=True,
         approx_pass=None,
         solver="SESolver",
-        solver_options={},
+        solver_options=None,
     ):
         super().__init__()
 
@@ -54,7 +64,7 @@ class DynamiqsBackend(BackendBase):
         self.intermediate = None
         self.approx_pass = approx_pass
         self.solver = solver
-        self.solver_options = solver_options
+        self.solver_options = normalize_solver_options(solver_options)
 
     def compile(self, circuit, fock_cutoff, *, relabel=True):
         """
@@ -87,7 +97,6 @@ class DynamiqsBackend(BackendBase):
 
         get_hilbert_space = GetHilbertSpace()
         analysis = Post(get_hilbert_space)
-        analysis(intermediate)
 
         if relabel:
             analysis(intermediate)
@@ -143,3 +152,45 @@ class DynamiqsBackend(BackendBase):
         vm(experiment)
 
         return vm.children[0].result
+
+    def run_task(
+        self,
+        task: Task,
+        *,
+        relabel: bool = True,
+        initial_state=None,
+    ):
+        """
+        Compile and run an atomic-layer [`Task`][oqd_core.backend.task.Task].
+
+        Expects ``task.program`` to be an [`AtomicCircuit`][oqd_core.interface.atomic.AtomicCircuit]
+        and ``task.args`` to be [`TaskArgsAtomic`][oqd_core.backend.task.TaskArgsAtomic]
+        or [`TaskArgsAtomicEmulator`][oqd_trical.backend.dynamiqs.task.TaskArgsAtomicEmulator]
+        (the latter adds ``dynamiqs_solver_options``).
+
+        Returns:
+            Same dict as [`run`][oqd_trical.backend.dynamiqs.DynamiqsBackend.run]
+            (``final_state``, ``states``, ``tspan``, ...).
+        """
+        if not isinstance(task.program, AtomicCircuit):
+            raise TypeError(
+                "DynamiqsBackend.run_task expects task.program to be AtomicCircuit."
+            )
+        if not isinstance(task.args, (TaskArgsAtomic, TaskArgsAtomicEmulator)):
+            raise TypeError(
+                "DynamiqsBackend.run_task expects TaskArgsAtomic or TaskArgsAtomicEmulator."
+            )
+
+        fock_trunc, dt, solver_opts = task_args_from_atomic(task.args)
+        if solver_opts is not None:
+            self.solver_options = normalize_solver_options(solver_opts)
+
+        experiment, hilbert_space = self.compile(
+            task.program, fock_trunc, relabel=relabel
+        )
+        return self.run(
+            experiment,
+            hilbert_space,
+            dt,
+            initial_state=initial_state,
+        )

--- a/src/oqd_trical/backend/dynamiqs/codegen.py
+++ b/src/oqd_trical/backend/dynamiqs/codegen.py
@@ -87,7 +87,15 @@ class DynamiqsCodeGeneration(ConversionRule):
         )
 
     def map_OperatorMul(self, model, operands):
-        return lambda t: operands["op1"](t) @ operands["op2"](t)
+        op1, op2 = operands["op1"], operands["op2"]
+
+        def combined(t):
+            m1, m2 = op1(t), op2(t)
+            if m1.shape != m2.shape:
+                return dq.tensor(m1, m2)
+            return m1 @ m2
+
+        return combined
 
     def map_OperatorKron(self, model, operands):
         return lambda t: dq.tensor(operands["op1"](t), operands["op2"](t))

--- a/src/oqd_trical/backend/dynamiqs/solver.py
+++ b/src/oqd_trical/backend/dynamiqs/solver.py
@@ -1,0 +1,107 @@
+# Copyright 2024-2025 Open Quantum Design
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Diffrax / Dynamiqs integration settings for the TrICal Dynamiqs backend.
+
+Unit convention (matches QuTiP and the atomic-interface lowering):
+  - Level energies, phonon energies, Rabi frequencies, and detunings are angular
+    frequencies in rad/s (inputs often carry explicit factors of 2*pi).
+  - Pulse durations are in seconds.
+  - The lowered Hamiltonian H and ``tsave`` passed to ``dq.sesolve`` use the same
+    rad/s and second units; Dynamiqs integrates d|psi>/dt = -i H |psi> with hbar=1.
+
+Adaptive step-size controllers are sensitive to |H| and the integration interval.
+Trapped-ion circuits after rotating-frame and RWA passes typically have |H| ~ 2*pi
+* 1e6 rad/s or smaller; default tolerances are relaxed slightly versus Dynamiqs'
+library defaults so stiff sideband dynamics do not exhaust ``max_steps``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Union
+
+import dynamiqs as dq
+
+########################################################################################
+
+# Tsit5 uses a Diffrax PID step-size controller (see dynamiqs.method.Tsit5).
+# 1e-6 (library default) can exhaust max_steps on ~MHz-scale trapped-ion dynamics;
+# 1e-3 matches QuTiP SESolver on reference circuits to within ~5% on populations.
+DEFAULT_RTOL = 1e-3
+DEFAULT_ATOL = 1e-3
+DEFAULT_MAX_STEPS = 2_000_000
+
+
+@dataclass
+class DynamiqsSolverOptions:
+    """Options forwarded to ``dq.sesolve`` / ``dq.mesolve`` (Diffrax under the hood).
+
+    Pass an instance via ``DynamiqsBackend(solver_options=...)`` or a plain dict with
+    the same keys. Mirrors the role of QuTiP's ``solver_options`` on
+    ``QutipBackend``.
+    """
+
+    rtol: float = DEFAULT_RTOL
+    atol: float = DEFAULT_ATOL
+    max_steps: int = DEFAULT_MAX_STEPS
+    method: Optional[Any] = None
+    options: Optional[Any] = None
+    # Rescale t -> omega*t and H -> H/omega so Diffrax sees O(1) frequencies (rad/s in, seconds in).
+    rescale_time: bool = True
+    time_scale: Optional[float] = None
+
+    def to_solver_dict(self) -> Dict[str, Any]:
+        method = self.method
+        if method is None:
+            method = dq.method.Tsit5(
+                rtol=self.rtol, atol=self.atol, max_steps=self.max_steps
+            )
+        options = self.options
+        if options is None:
+            options = dq.Options(progress_meter=False)
+        return {
+            "method": method,
+            "options": options,
+            "rescale_time": self.rescale_time,
+            "time_scale": self.time_scale,
+        }
+
+
+def normalize_solver_options(
+    solver_options: Optional[Union[DynamiqsSolverOptions, Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    if solver_options is None:
+        return DynamiqsSolverOptions().to_solver_dict()
+    if isinstance(solver_options, DynamiqsSolverOptions):
+        return solver_options.to_solver_dict()
+    if "method" not in solver_options:
+        opts = DynamiqsSolverOptions(
+            rtol=solver_options.get("rtol", DEFAULT_RTOL),
+            atol=solver_options.get("atol", DEFAULT_ATOL),
+            max_steps=solver_options.get("max_steps", DEFAULT_MAX_STEPS),
+            method=solver_options.get("method"),
+            options=solver_options.get("options"),
+            rescale_time=solver_options.get("rescale_time", True),
+            time_scale=solver_options.get("time_scale"),
+        )
+        merged = opts.to_solver_dict()
+        merged.update({k: v for k, v in solver_options.items() if k not in merged})
+        return merged
+    if "options" not in solver_options:
+        solver_options = {
+            **solver_options,
+            "options": dq.Options(progress_meter=False),
+        }
+    return solver_options

--- a/src/oqd_trical/backend/dynamiqs/task.py
+++ b/src/oqd_trical/backend/dynamiqs/task.py
@@ -1,0 +1,56 @@
+# Copyright 2024-2025 Open Quantum Design
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Task-level arguments for atomic-layer simulation with the Dynamiqs backend."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from oqd_core.backend.task import TaskArgsAtomic
+from pydantic import BaseModel, ConfigDict, Field
+
+from oqd_trical.backend.dynamiqs.solver import DynamiqsSolverOptions
+
+########################################################################################
+
+
+class TaskArgsAtomicEmulator(BaseModel):
+    """Extends atomic task args with optional Dynamiqs/Diffrax settings."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    fock_trunc: int = Field(default=4, description="Fock space truncation per phonon mode.")
+    dt: float = Field(
+        default=1e-8,
+        description="Output timestep between saved states (seconds).",
+    )
+    dynamiqs_solver_options: Optional[DynamiqsSolverOptions] = Field(
+        default=None,
+        description="Diffrax integrator settings (Tsit5, rtol/atol, time rescaling).",
+    )
+
+
+def task_args_from_atomic(
+    args: TaskArgsAtomic | TaskArgsAtomicEmulator,
+) -> tuple[int, float, Optional[DynamiqsSolverOptions]]:
+    """Normalize task args into (fock_trunc, dt, dynamiqs_solver_options)."""
+    fock = args.fock_trunc
+    dt = args.dt
+    solver = (
+        args.dynamiqs_solver_options
+        if isinstance(args, TaskArgsAtomicEmulator)
+        else None
+    )
+    return fock, dt, solver

--- a/src/oqd_trical/backend/dynamiqs/vm.py
+++ b/src/oqd_trical/backend/dynamiqs/vm.py
@@ -17,6 +17,8 @@ from dynamiqs import mesolve, sesolve
 from jax import numpy as jnp
 from oqd_compiler_infrastructure import RewriteRule
 
+from oqd_trical.backend.dynamiqs.solver import normalize_solver_options
+
 ########################################################################################
 
 
@@ -26,9 +28,10 @@ class DynamiqsVM(RewriteRule):
 
     Attributes:
         hilbert_space (Dict[str, int]): Hilbert space of the system.
-        timestep (float): Timestep between tracked states of the evolution.
+        timestep (float): Timestep between tracked states of the evolution (seconds).
         solver (Literal["SESolver","MESolver"]): Dynamiqs solver to use.
-        solver_options (Dict[str,Any]): Dynamiqs solver options
+        solver_options (Dict[str,Any]): Keys ``method`` (dq.method.*) and ``options``
+            (dq.Options); see [`DynamiqsSolverOptions`][oqd_trical.backend.dynamiqs.solver.DynamiqsSolverOptions].
     """
 
     def __init__(
@@ -38,7 +41,7 @@ class DynamiqsVM(RewriteRule):
         *,
         initial_state=None,
         solver="SESolver",
-        solver_options={},
+        solver_options=None,
     ):
         self.hilbert_space = hilbert_space
         self.timestep = timestep
@@ -62,7 +65,7 @@ class DynamiqsVM(RewriteRule):
             "SESolver": sesolve,
             "MESolver": mesolve,
         }[solver]
-        self.solver_options = solver_options
+        self.solver_options = normalize_solver_options(solver_options)
 
     @property
     def result(self):
@@ -88,20 +91,60 @@ class DynamiqsVM(RewriteRule):
         empty_hamiltonian = model.hamiltonian is None
 
         if empty_hamiltonian:
-            self.tspan.extend(list(tspan[1:] + self.tspan[-1]))
+            self.tspan.extend(list(tspan[1:]))
             self.states.extend([self.current_state] * (len(tspan) - 1))
             return
 
-        res = self.solver(
+        hamiltonian, tspan_solve = _prepare_hamiltonian_and_tspan(
             model.hamiltonian,
-            self.current_state,
             tspan,
-            solver=self.solver_options["solver"]
-            if "solver" in self.solver_options.keys()
-            else dq.solver.Tsit5(),
+            model.duration,
+            rescale_time=self.solver_options.get("rescale_time", True),
+            time_scale=self.solver_options.get("time_scale"),
+        )
+
+        res = self.solver(
+            hamiltonian,
+            self.current_state,
+            tspan_solve,
+            method=self.solver_options["method"],
+            options=self.solver_options["options"],
         )
 
         self.current_state = res.final_state
 
         self.tspan.extend(list(tspan[1:]))
         self.states.extend(list(res.states[1:]))
+
+
+def _hamiltonian_scale(hamiltonian, duration: float) -> float:
+    """Characteristic angular frequency (rad/s) for dimensionless time rescaling."""
+    omega = float(jnp.max(jnp.abs(hamiltonian(0.0).to_jax())))
+    if duration > 0:
+        omega = max(
+            omega, float(jnp.max(jnp.abs(hamiltonian(duration).to_jax())))
+        )
+    return max(omega, 1.0)
+
+
+def _prepare_hamiltonian_and_tspan(
+    hamiltonian,
+    tspan,
+    duration: float,
+    *,
+    rescale_time: bool,
+    time_scale: float | None,
+):
+    """Optionally rescale to dimensionless time for Diffrax (see solver module docstring)."""
+    if not rescale_time:
+        return hamiltonian, tspan
+
+    omega = float(
+        time_scale
+        if time_scale is not None
+        else _hamiltonian_scale(hamiltonian, duration)
+    )
+    # Compose with the inner callable; avoid nesting timecallable(TimeQArray).
+    base = hamiltonian.f if hasattr(hamiltonian, "f") else hamiltonian
+    hamiltonian = dq.timecallable(lambda tau, f=base, om=omega: f(tau / om) / om)
+    return hamiltonian, tspan * omega

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -13,13 +13,118 @@
 # limitations under the License.
 
 ########################################################################################
-import dynamiqs as dq
-import pytest
-import qutip as qt
 
+import numpy as np
+import pytest
+
+try:
+    import dynamiqs as dq
+    import qutip as qt
+except ImportError:
+    pytest.skip("dynamiqs or qutip not installed", allow_module_level=True)
+
+from oqd_compiler_infrastructure import Chain, Post
+from oqd_core.backend.task import Task
+from oqd_core.interface.atomic import (
+    AtomicCircuit,
+    Beam,
+    Phonon,
+    Pulse,
+    SequentialProtocol,
+    System,
+    Yb171IIBuilder,
+)
+
+from oqd_trical.backend import DynamiqsBackend, DynamiqsSolverOptions, QutipBackend
+from oqd_trical.backend.dynamiqs.task import TaskArgsAtomicEmulator
 from oqd_trical.backend.dynamiqs.vm import DynamiqsVM
 from oqd_trical.backend.qutip.vm import QutipVM
 from oqd_trical.light_matter.compiler.analysis import HilbertSpace
+from oqd_trical.light_matter.compiler.approximate import (
+    RotatingReferenceFrame,
+    RotatingWaveApprox,
+)
+from oqd_trical.light_matter.compiler.canonicalize import (
+    canonicalize_emulator_circuit_factory,
+)
+
+########################################################################################
+
+# Population tolerance for QuTiP vs Dynamiqs agreement on matched Hamiltonian units.
+POPULATION_RTOL = 5e-2
+TIMESTEP = 1e-8
+FOCK_CUTOFF = 3
+
+
+def _approx_pass(frame_specs):
+    return Chain(
+        Post(RotatingReferenceFrame(frame_specs=frame_specs)),
+        canonicalize_emulator_circuit_factory(),
+        Post(RotatingWaveApprox(cutoff=2 * np.pi * 1e9)),
+    )
+
+
+def _excited_populations(result, hilbert_space, backend):
+    n = hilbert_space.size["E0"]
+    nf = hilbert_space.size["P0"]
+    if backend == "qutip":
+        proj = qt.tensor(
+            qt.basis(n, 1) * qt.basis(n, 1).dag(),
+            qt.qeye(nf),
+        )
+        return [float(qt.expect(proj, state).real) for state in result["states"]]
+    proj = dq.tensor(dq.basis(n, 1) @ dq.basis(n, 1).dag(), dq.eye(nf))
+    return [float(dq.expect(proj, state).real) for state in result["states"]]
+
+
+def _run_both(circuit, frame_specs):
+    approx = _approx_pass(frame_specs)
+    q_backend = QutipBackend(approx_pass=approx, solver_options={"progress_bar": False})
+    d_backend = DynamiqsBackend(approx_pass=approx)
+    q_exp, hs = q_backend.compile(circuit, FOCK_CUTOFF)
+    d_exp, _ = d_backend.compile(circuit, FOCK_CUTOFF)
+    q_res = q_backend.run(q_exp, hs, TIMESTEP)
+    d_res = d_backend.run(d_exp, hs, TIMESTEP)
+    return q_res, d_res, hs
+
+
+def _microwave_rabi_circuit():
+    ion = Yb171IIBuilder().build(["q0", "q1"])
+    com = Phonon(energy=2 * np.pi * 1e6, eigenvector=[1, 0, 0])
+    system = System(ions=[ion], modes=[com])
+    beam = Beam(
+        transition="q0->q1",
+        rabi=2 * np.pi * 1e6,
+        detuning=0,
+        phase=0,
+        polarization=[0, 1, 0],
+        wavevector=[1, 0, 0],
+        target=0,
+    )
+    protocol = SequentialProtocol(sequence=[Pulse(beam=beam, duration=1e-6)])
+    circuit = AtomicCircuit(system=system, protocol=protocol)
+    frame_specs = {"E0": [level.energy for level in ion.levels], "P0": 2 * np.pi * 1e6}
+    return circuit, frame_specs
+
+
+def _red_sideband_circuit():
+    ion = Yb171IIBuilder().build(["q1", "e0"])
+    com = Phonon(energy=2 * np.pi * 1e6, eigenvector=[1, 0, 0])
+    system = System(ions=[ion], modes=[com])
+    beam = Beam(
+        transition="q1->e0",
+        rabi=2 * np.pi * 1e6,
+        detuning=-2 * np.pi * 1.1e6,
+        phase=0,
+        polarization=[0, 0, 1],
+        wavevector=[1, 0, 0],
+        target=0,
+    )
+    protocol = SequentialProtocol(sequence=[Pulse(beam=beam, duration=1e-5)])
+    circuit = AtomicCircuit(system=system, protocol=protocol)
+    frame_specs = {"E0": [level.energy for level in ion.levels], "P0": 2 * np.pi * 1e6}
+    return circuit, frame_specs
+
 
 ########################################################################################
 
@@ -50,3 +155,71 @@ class TestInitialStateVM:
         initial_state = dq.tensor(dq.basis(2, 0), dq.basis(3, 0))
 
         DynamiqsVM(hilbert_space=hilbert_space, timestep=1, initial_state=initial_state)
+
+
+class TestDynamiqsSolverOptions:
+    def test_default_progress_meter_disabled(self):
+        opts = DynamiqsSolverOptions().to_solver_dict()
+        assert opts["options"].progress_meter is False
+
+    def test_backend_accepts_solver_options_model(self):
+        backend = DynamiqsBackend(solver_options=DynamiqsSolverOptions(rtol=1e-4))
+        assert backend.solver_options["method"].rtol == 1e-4
+
+
+class TestBackendParity:
+    def test_single_ion_rabi_carrier(self):
+        circuit, frame_specs = _microwave_rabi_circuit()
+        q_res, d_res, hs = _run_both(circuit, frame_specs)
+        pq = _excited_populations(q_res, hs, "qutip")
+        pd = _excited_populations(d_res, hs, "dynamiqs")
+        assert len(pq) == len(pd)
+        np.testing.assert_allclose(pq, pd, rtol=POPULATION_RTOL, atol=POPULATION_RTOL)
+
+    def test_single_ion_red_sideband(self):
+        circuit, frame_specs = _red_sideband_circuit()
+        q_res, d_res, hs = _run_both(circuit, frame_specs)
+        pq = _excited_populations(q_res, hs, "qutip")
+        pd = _excited_populations(d_res, hs, "dynamiqs")
+        assert len(pq) == len(pd)
+        np.testing.assert_allclose(pq, pd, rtol=POPULATION_RTOL, atol=POPULATION_RTOL)
+
+    def test_hamiltonian_matches_qutip_at_gate_times(self):
+        circuit, frame_specs = _microwave_rabi_circuit()
+        approx = _approx_pass(frame_specs)
+        q_exp, _ = QutipBackend(approx_pass=approx).compile(circuit, FOCK_CUTOFF)
+        d_exp, _ = DynamiqsBackend(approx_pass=approx).compile(circuit, FOCK_CUTOFF)
+        Hq = q_exp.sequence[0].hamiltonian
+        Hd = d_exp.sequence[0].hamiltonian
+        for t in (0.0, 0.5e-6, 1e-6):
+            Mq = Hq(t).full()
+            Md = np.asarray(Hd(t).to_jax())
+            rel = np.linalg.norm(Mq - Md) / np.linalg.norm(Mq)
+            assert rel < 1e-4, f"relative Hamiltonian mismatch at t={t}: {rel}"
+
+    def test_run_task_entry_point(self):
+        from oqd_core.backend.task import TaskArgsAtomic
+
+        circuit, frame_specs = _microwave_rabi_circuit()
+        task = Task(
+            program=circuit,
+            args=TaskArgsAtomic(fock_trunc=FOCK_CUTOFF, dt=TIMESTEP),
+        )
+        result = DynamiqsBackend(approx_pass=_approx_pass(frame_specs)).run_task(task)
+        assert len(result["states"]) > 1
+        assert result["tspan"][-1] == pytest.approx(1e-6)
+
+    def test_run_task_with_emulator_solver_options(self):
+        circuit, frame_specs = _microwave_rabi_circuit()
+        # oqd-core Task.args is only TaskArgsAtomic today; construct bypasses that union.
+        task = Task.model_construct(
+            program=circuit,
+            args=TaskArgsAtomicEmulator(
+                fock_trunc=FOCK_CUTOFF,
+                dt=TIMESTEP,
+                dynamiqs_solver_options=DynamiqsSolverOptions(rtol=1e-4),
+            ),
+        )
+        backend = DynamiqsBackend(approx_pass=_approx_pass(frame_specs))
+        backend.run_task(task)
+        assert backend.solver_options["method"].rtol == 1e-4


### PR DESCRIPTION
## Summary

Fixes Dynamiqs `sesolve` integration so `AtomicCircuit` simulations run end-to-end and agree with QuTiP on reference Rabi and red-sideband circuits.

## Changes

- Fix `dq.sesolve` (`method=dq.method.Tsit5`, not invalid `solver` / `dq.solver`)
- Add `DynamiqsSolverOptions` (units, Tsit5, rtol/atol, optional time rescaling, `progress_meter=False` for Jupyter/#26)
- Fix duplicate Hilbert-space analysis in `DynamiqsBackend.compile`; tensor product in cross-subsystem `OperatorMul`
- `DynamiqsBackend.run_task()` + `TaskArgsAtomicEmulator` for Diffrax options (until promoted in oqd-core)
- Parity tests vs QuTiP; minimal docs fix (Dynamiqs link + short units note)

## Test plan

- [x] `uv run pytest tests/test_backends.py -v` (9 passed, 2 xfailed)

Fixes #43