### PR TITLE
[fix] Repair Dynamiqs backend resolve and add QuTiP parity tests

### DIFF
--- a/docs/explanation/backends.md
+++ b/docs/explanation/backends.md
@@ -5,7 +5,7 @@ Backends are used to execute the AtomicCircuit.
 ## Supported Backends
 
 - [QuTiP](https://qutip.readthedocs.io/en/latest/) <div style="float:right;"> [![](https://img.shields.io/badge/Implementation-7C4DFF)][oqd_trical.backend.qutip.QutipBackend] </div>
-- [Dynamiqs](https://qutip.readthedocs.io/en/latest/) <div style="float:right;"> [![](https://img.shields.io/badge/Implementation-7C4DFF)][oqd_trical.backend.dynamiqs.DynamiqsBackend] </div>
+- [Dynamiqs](https://www.dynamiqs.org/) <div style="float:right;"> [![](https://img.shields.io/badge/Implementation-7C4DFF)][oqd_trical.backend.dynamiqs.DynamiqsBackend] </div>
 
 ## Compile
 
@@ -30,5 +30,44 @@ Executes the compatible form of the AtomicCircuit with the backend using a tree 
 
 - QuTiP uses [`QutipVM`][oqd_trical.backend.qutip.vm.QutipVM] as its tree walking interpreter.
 - Dynamiqs uses [`DynamiqsVM`][oqd_trical.backend.dynamiqs.vm.DynamiqsVM] as its tree walking interpreter.
+
+///
+
+## Units and solver options (Dynamiqs)
+
+The Dynamiqs backend integrates the Schrödinger equation
+$\frac{d}{dt}\lvert\psi\rangle = -i H \lvert\psi\rangle$ with $\hbar = 1$. Units flow
+consistently from the atomic interface to [`dq.sesolve`](https://www.dynamiqs.org/):
+
+- Level energies, beam Rabi frequencies and detunings are **angular frequencies
+  (rad/s)**, so the lowered Hamiltonian is in rad/s.
+- Pulse durations and the save `timestep` are in **seconds**.
+- The phase accumulated by a time-dependent coefficient is `frequency * t`
+  (rad/s × s), which is dimensionless.
+
+Because the bare optical carrier ($\sim 2\pi\cdot 10^{15}$ rad/s) makes the equation
+stiff, drive it through the
+[`RotatingReferenceFrame`][oqd_trical.light_matter.compiler.approximate.RotatingReferenceFrame]
+and [`RotatingWaveApprox`][oqd_trical.light_matter.compiler.approximate.RotatingWaveApprox]
+passes, which remove the carrier and leave a slowly varying Hamiltonian. Accuracy
+is then controlled by the explicit Diffrax tolerances rather than by rescaling time.
+
+The Diffrax solver, its tolerances and the step-size controller are set explicitly via
+[`DynamiqsSolverOptions`][oqd_trical.backend.dynamiqs.solver_options.DynamiqsSolverOptions]
+(default: `Tsit5` with `rtol = atol = 1e-8`), passed as `solver_options` to the
+backend. The progress meter is disabled by default to avoid the `ZMQError` raised by
+`tqdm` inside Jupyter (issue #26).
+
+<!-- prettier-ignore -->
+/// admonition | Example
+    type: example
+
+```python
+from oqd_trical.backend import DynamiqsBackend, DynamiqsSolverOptions
+
+backend = DynamiqsBackend(
+    solver_options=DynamiqsSolverOptions(rtol=1e-8, atol=1e-8),
+)
+```
 
 ///

--- a/src/oqd_trical/backend/__init__.py
+++ b/src/oqd_trical/backend/__init__.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 from . import dynamiqs, qutip
-from .dynamiqs import DynamiqsBackend
+from .dynamiqs import DynamiqsBackend, DynamiqsSolverOptions, TaskArgsAtomicEmulator
 from .qutip import QutipBackend
 
 __all__ = [
     "qutip",
     "dynamiqs",
     "DynamiqsBackend",
+    "DynamiqsSolverOptions",
+    "TaskArgsAtomicEmulator",
     "QutipBackend",
 ]

--- a/src/oqd_trical/backend/dynamiqs/__init__.py
+++ b/src/oqd_trical/backend/dynamiqs/__init__.py
@@ -14,10 +14,14 @@
 
 from .base import DynamiqsBackend
 from .codegen import DynamiqsCodeGeneration
+from .solver_options import DynamiqsSolverOptions
+from .task import TaskArgsAtomicEmulator
 from .vm import DynamiqsVM
 
 __all__ = [
     "DynamiqsBackend",
     "DynamiqsCodeGeneration",
+    "DynamiqsSolverOptions",
+    "TaskArgsAtomicEmulator",
     "DynamiqsVM",
 ]

--- a/src/oqd_trical/backend/dynamiqs/base.py
+++ b/src/oqd_trical/backend/dynamiqs/base.py
@@ -18,6 +18,7 @@ from oqd_core.compiler.atomic.canonicalize import canonicalize_atomic_circuit_fa
 from oqd_core.interface.atomic import AtomicCircuit
 
 from oqd_trical.backend.dynamiqs.codegen import DynamiqsCodeGeneration
+from oqd_trical.backend.dynamiqs.solver_options import DynamiqsSolverOptions
 from oqd_trical.backend.dynamiqs.vm import DynamiqsVM
 from oqd_trical.light_matter.compiler.analysis import GetHilbertSpace, HilbertSpace
 from oqd_trical.light_matter.compiler.canonicalize import (
@@ -37,7 +38,9 @@ class DynamiqsBackend(BackendBase):
         save_intermediate (bool): Whether compiler saves the intermediate representation of the atomic circuit
         approx_pass (PassBase): Pass of approximations to apply to the system.
         solver (Literal["SESolver","MESolver"]): Dynamiqs solver to use.
-        solver_options (Dict[str,Any]): Dynamiqs solver options
+        solver_options (DynamiqsSolverOptions): Dynamiqs solver options. Accepts a
+            [`DynamiqsSolverOptions`][oqd_trical.backend.dynamiqs.solver_options.DynamiqsSolverOptions],
+            a dict of its fields, or None for the documented defaults.
         intermediate (AtomicEmulatorCircuit): Intermediate representation of the atomic circuit during compilation
     """
 
@@ -46,7 +49,7 @@ class DynamiqsBackend(BackendBase):
         save_intermediate=True,
         approx_pass=None,
         solver="SESolver",
-        solver_options={},
+        solver_options=None,
     ):
         super().__init__()
 
@@ -54,7 +57,7 @@ class DynamiqsBackend(BackendBase):
         self.intermediate = None
         self.approx_pass = approx_pass
         self.solver = solver
-        self.solver_options = solver_options
+        self.solver_options = DynamiqsSolverOptions.from_obj(solver_options)
 
     def compile(self, circuit, fock_cutoff, *, relabel=True):
         """
@@ -87,7 +90,6 @@ class DynamiqsBackend(BackendBase):
 
         get_hilbert_space = GetHilbertSpace()
         analysis = Post(get_hilbert_space)
-        analysis(intermediate)
 
         if relabel:
             analysis(intermediate)
@@ -105,7 +107,7 @@ class DynamiqsBackend(BackendBase):
         hilbert_space = HilbertSpace(hilbert_space=_hilbert_space)
 
         if any(map(lambda x: x is None, hilbert_space.hilbert_space.values())):
-            raise "Hilbert space not fully specified."
+            raise ValueError("Hilbert space not fully specified.")
 
         relabeller = Post(RelabelStates(hilbert_space.get_relabel_rules()))
         intermediate = relabeller(intermediate)
@@ -136,6 +138,43 @@ class DynamiqsBackend(BackendBase):
                 timestep=timestep,
                 solver=self.solver,
                 solver_options=self.solver_options,
+                initial_state=initial_state,
+            )
+        )
+
+        vm(experiment)
+
+        return vm.children[0].result
+
+    def run_task(self, task, *, initial_state=None):
+        """
+        Runs an AtomicCircuit carried by a Task.
+
+        Mirrors the Task entry point of oqd-analog-emulator's QutipBackend. The
+        Fock cutoff and timestep are taken from the task args' fock_trunc and dt;
+        the Diffrax options come from the
+        [`TaskArgsAtomicEmulator`][oqd_trical.backend.dynamiqs.task.TaskArgsAtomicEmulator]
+        solver_options, falling back to the backend's own solver_options when unset.
+
+        Args:
+            task (Task): Task whose program is an AtomicCircuit and whose args are a
+                [`TaskArgsAtomicEmulator`][oqd_trical.backend.dynamiqs.task.TaskArgsAtomicEmulator].
+
+        Returns:
+            result (Dict[str,Any]): Result of execution, as returned by run().
+        """
+        args = task.args
+        solver = getattr(args, "solver", self.solver)
+        solver_options = getattr(args, "solver_options", None) or self.solver_options
+
+        experiment, hilbert_space = self.compile(task.program, args.fock_trunc)
+
+        vm = Pre(
+            DynamiqsVM(
+                hilbert_space=hilbert_space,
+                timestep=args.dt,
+                solver=solver,
+                solver_options=solver_options,
                 initial_state=initial_state,
             )
         )

--- a/src/oqd_trical/backend/dynamiqs/codegen.py
+++ b/src/oqd_trical/backend/dynamiqs/codegen.py
@@ -31,6 +31,10 @@ class DynamiqsCodeGeneration(ConversionRule):
     Rule that converts an [`AtomicEmulatorCircuit`][oqd_trical.light_matter.interface.emulator.AtomicEmulatorCircuit]
     to a [`DynamiqsExperiment`][oqd_trical.backend.dynamiqs.interface.DynamiqsExperiment]
 
+    Operators and coefficients are in angular frequency (rad/s) and time t is in
+    seconds, matching the atomic interface; the Hamiltonian is integrated with
+    hbar = 1.
+
     Attributes:
         hilbert_space (Dict[str, int]): Hilbert space of the system.
     """

--- a/src/oqd_trical/backend/dynamiqs/interface.py
+++ b/src/oqd_trical/backend/dynamiqs/interface.py
@@ -28,8 +28,8 @@ class DynamiqsExperiment(TypeReflectBaseModel):
     Class representing a Dynamiqs experiment represented in terms of atomic operations expressed in terms of their Hamiltonians.
 
     Attributes:
-        base (Operator): Free Hamiltonian.
-        sequence (List[AtomicEmulatorGate]): List of gates to apply.
+        frame (Optional[dq.TimeQArray]): Time-dependent frame transformation, if any.
+        sequence (List[DynamiqsGate]): List of gates to apply.
 
     """
 

--- a/src/oqd_trical/backend/dynamiqs/solver_options.py
+++ b/src/oqd_trical/backend/dynamiqs/solver_options.py
@@ -1,0 +1,70 @@
+# Copyright 2024-2025 Open Quantum Design
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Literal
+
+import dynamiqs as dq
+from pydantic import BaseModel, ConfigDict
+
+########################################################################################
+
+
+class DynamiqsSolverOptions(BaseModel):
+    """Explicit Diffrax solver options for the Dynamiqs backend.
+
+    Builds the Dynamiqs method and options passed to each sesolve call. Tolerances
+    live on the integration method, from which Dynamiqs configures the Diffrax
+    PIDController.
+
+    Attributes:
+        method (str): Adaptive ODE method, one of Tsit5, Dopri5, Dopri8, Kvaerno3
+            or Kvaerno5. Defaults to Tsit5.
+        rtol (float): Relative tolerance of the step-size controller. Defaults to 1e-8.
+        atol (float): Absolute tolerance of the step-size controller. Defaults to 1e-8.
+        max_steps (int): Maximum number of solver steps. Defaults to 1000000.
+        progress_meter (bool): Show the Dynamiqs progress meter. Defaults to False to
+            avoid a tqdm/ZMQError under Jupyter (issue #26).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    method: Literal["Tsit5", "Dopri5", "Dopri8", "Kvaerno3", "Kvaerno5"] = "Tsit5"
+    rtol: float = 1e-8
+    atol: float = 1e-8
+    max_steps: int = 1_000_000
+    progress_meter: bool = False
+
+    def to_method(self):
+        """Build the Dynamiqs adaptive integration method instance."""
+        return getattr(dq.method, self.method)(
+            rtol=self.rtol, atol=self.atol, max_steps=self.max_steps
+        )
+
+    def to_options(self):
+        """Build the Dynamiqs solver options."""
+        return dq.Options(progress_meter=self.progress_meter)
+
+    @classmethod
+    def from_obj(cls, obj):
+        """Normalize None, a dict or a DynamiqsSolverOptions into an instance."""
+        if obj is None:
+            return cls()
+        if isinstance(obj, cls):
+            return obj
+        if isinstance(obj, dict):
+            return cls(**obj)
+        raise TypeError(
+            "solver_options must be None, a dict, or a DynamiqsSolverOptions, "
+            f"got {type(obj).__name__}"
+        )

--- a/src/oqd_trical/backend/dynamiqs/task.py
+++ b/src/oqd_trical/backend/dynamiqs/task.py
@@ -1,0 +1,38 @@
+# Copyright 2024-2025 Open Quantum Design
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Literal, Optional
+
+from oqd_core.backend.task import TaskArgsAtomic
+
+from oqd_trical.backend.dynamiqs.solver_options import DynamiqsSolverOptions
+
+########################################################################################
+
+
+class TaskArgsAtomicEmulator(TaskArgsAtomic):
+    """Task arguments for the Dynamiqs backend.
+
+    Extends TaskArgsAtomic with the Diffrax solver and its options, so a Task can
+    carry them to
+    [`DynamiqsBackend.run_task`][oqd_trical.backend.dynamiqs.DynamiqsBackend.run_task].
+    The inherited fock_trunc and dt set the Fock cutoff and the timestep.
+
+    Attributes:
+        solver (Literal["SESolver","MESolver"]): Dynamiqs solver to use.
+        solver_options (Optional[DynamiqsSolverOptions]): Dynamiqs solver options.
+    """
+
+    solver: Literal["SESolver", "MESolver"] = "SESolver"
+    solver_options: Optional[DynamiqsSolverOptions] = None

--- a/src/oqd_trical/backend/dynamiqs/vm.py
+++ b/src/oqd_trical/backend/dynamiqs/vm.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 import dynamiqs as dq
+import numpy as np
 from dynamiqs import mesolve, sesolve
 from jax import numpy as jnp
 from oqd_compiler_infrastructure import RewriteRule
+
+from oqd_trical.backend.dynamiqs.solver_options import DynamiqsSolverOptions
 
 ########################################################################################
 
@@ -28,7 +31,7 @@ class DynamiqsVM(RewriteRule):
         hilbert_space (Dict[str, int]): Hilbert space of the system.
         timestep (float): Timestep between tracked states of the evolution.
         solver (Literal["SESolver","MESolver"]): Dynamiqs solver to use.
-        solver_options (Dict[str,Any]): Dynamiqs solver options
+        solver_options (DynamiqsSolverOptions): Dynamiqs solver options.
     """
 
     def __init__(
@@ -38,12 +41,12 @@ class DynamiqsVM(RewriteRule):
         *,
         initial_state=None,
         solver="SESolver",
-        solver_options={},
+        solver_options=None,
     ):
         self.hilbert_space = hilbert_space
         self.timestep = timestep
 
-        if initial_state:
+        if initial_state is not None:
             if initial_state.dims != tuple(self.hilbert_space.size.values()):
                 raise ValueError("Initial state incompatible with Hilbert space")
             self.current_state = initial_state
@@ -62,7 +65,9 @@ class DynamiqsVM(RewriteRule):
             "SESolver": sesolve,
             "MESolver": mesolve,
         }[solver]
-        self.solver_options = solver_options
+        self.solver_options = DynamiqsSolverOptions.from_obj(solver_options)
+        self._method = self.solver_options.to_method()
+        self._options = self.solver_options.to_options()
 
     @property
     def result(self):
@@ -78,30 +83,28 @@ class DynamiqsVM(RewriteRule):
         self.frame = model.frame
 
     def map_DynamiqsGate(self, model):
-        tspan = jnp.arange(0, model.duration, self.timestep)
+        # duration and timestep are concrete floats, so build the save times
+        # host-side with numpy and keep traced values out of the solve call
+        t0 = self.tspan[-1]
+        tspan = np.arange(0, model.duration, self.timestep)
+        if tspan.size == 0 or tspan[-1] != model.duration:
+            tspan = np.append(tspan, model.duration)
+        tspan = tspan + t0
 
-        if tspan[-1] != model.duration:
-            tspan = jnp.append(tspan, model.duration)
-
-        tspan = tspan + self.tspan[-1]
-
-        empty_hamiltonian = model.hamiltonian is None
-
-        if empty_hamiltonian:
-            self.tspan.extend(list(tspan[1:] + self.tspan[-1]))
+        if model.hamiltonian is None:
+            self.tspan.extend(tspan[1:].tolist())
             self.states.extend([self.current_state] * (len(tspan) - 1))
             return
 
         res = self.solver(
             model.hamiltonian,
             self.current_state,
-            tspan,
-            solver=self.solver_options["solver"]
-            if "solver" in self.solver_options.keys()
-            else dq.solver.Tsit5(),
+            jnp.asarray(tspan),
+            method=self._method,
+            options=self._options,
         )
 
         self.current_state = res.final_state
 
-        self.tspan.extend(list(tspan[1:]))
+        self.tspan.extend(tspan[1:].tolist())
         self.states.extend(list(res.states[1:]))

--- a/src/oqd_trical/backend/qutip/base.py
+++ b/src/oqd_trical/backend/qutip/base.py
@@ -104,7 +104,7 @@ class QutipBackend(BackendBase):
         hilbert_space = HilbertSpace(hilbert_space=_hilbert_space)
 
         if any(map(lambda x: x is None, hilbert_space.hilbert_space.values())):
-            raise "Hilbert space not fully specified."
+            raise ValueError("Hilbert space not fully specified.")
 
         relabeller = Post(RelabelStates(hilbert_space.get_relabel_rules()))
         intermediate = relabeller(intermediate)

--- a/src/oqd_trical/backend/qutip/vm.py
+++ b/src/oqd_trical/backend/qutip/vm.py
@@ -42,7 +42,7 @@ class QutipVM(RewriteRule):
         self.hilbert_space = hilbert_space
         self.timestep = timestep
 
-        if initial_state:
+        if initial_state is not None:
             if initial_state.dims[0] != list(self.hilbert_space.size.values()):
                 raise ValueError("Initial state incompatible with Hilbert space")
             self.current_state = initial_state
@@ -87,7 +87,7 @@ class QutipVM(RewriteRule):
         empty_hamiltonian = model.hamiltonian is None
 
         if empty_hamiltonian:
-            self.tspan.extend(list(tspan[1:] + self.tspan[-1]))
+            self.tspan.extend(list(tspan[1:]))
             self.states.extend([self.current_state] * (len(tspan) - 1))
             return
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -14,12 +14,44 @@
 
 ########################################################################################
 import dynamiqs as dq
+import jax
+import numpy as np
 import pytest
 import qutip as qt
+from jax import numpy as jnp
+from oqd_compiler_infrastructure import Chain, Post
+from oqd_core.backend.task import Task, TaskArgsAtomic
+from oqd_core.interface.atomic import (
+    AtomicCircuit,
+    Beam,
+    Phonon,
+    Pulse,
+    SequentialProtocol,
+    System,
+    Yb171IIBuilder,
+)
 
+from oqd_trical.backend import (
+    DynamiqsBackend,
+    DynamiqsSolverOptions,
+    QutipBackend,
+    TaskArgsAtomicEmulator,
+)
 from oqd_trical.backend.dynamiqs.vm import DynamiqsVM
 from oqd_trical.backend.qutip.vm import QutipVM
 from oqd_trical.light_matter.compiler.analysis import HilbertSpace
+from oqd_trical.light_matter.compiler.approximate import (
+    RotatingReferenceFrame,
+    RotatingWaveApprox,
+)
+from oqd_trical.light_matter.compiler.canonicalize import (
+    canonicalize_emulator_circuit_factory,
+)
+
+########################################################################################
+
+# Compare against the QuTiP reference in double precision (QuTiP uses float64).
+dq.set_precision("double")
 
 ########################################################################################
 
@@ -50,3 +82,319 @@ class TestInitialStateVM:
         initial_state = dq.tensor(dq.basis(2, 0), dq.basis(3, 0))
 
         DynamiqsVM(hilbert_space=hilbert_space, timestep=1, initial_state=initial_state)
+
+
+########################################################################################
+
+FOCK_CUTOFF = 3
+TIMESTEP = 1e-8
+
+
+def _approx_pass(levels):
+    frame_specs = {
+        "E0": [level.energy for level in levels],
+        "P0": 2 * np.pi * 1e6,
+    }
+    return Chain(
+        Post(RotatingReferenceFrame(frame_specs=frame_specs)),
+        canonicalize_emulator_circuit_factory(),
+        Post(RotatingWaveApprox(cutoff=2 * np.pi * 1e9)),
+    )
+
+
+def _microwave_circuit():
+    """Single-ion Rabi flop on the carrier (examples/direct/1_microwave)."""
+    ion = Yb171IIBuilder().build(["q0", "q1"])
+    system = System(
+        ions=[ion], modes=[Phonon(energy=2 * np.pi * 1e6, eigenvector=[1, 0, 0])]
+    )
+    beam = Beam(
+        transition="q0->q1",
+        rabi=2 * np.pi * 1e6,
+        detuning=0,
+        phase=0,
+        polarization=[0, 1, 0],
+        wavevector=[1, 0, 0],
+        target=0,
+    )
+    protocol = SequentialProtocol(sequence=[Pulse(beam=beam, duration=1e-6)])
+    return ion, AtomicCircuit(system=system, protocol=protocol)
+
+
+def _red_sideband_circuit():
+    """Single-ion + COM phonon red sideband (examples/direct/3a_red_sideband)."""
+    ion = Yb171IIBuilder().build(["q1", "e0"])
+    system = System(
+        ions=[ion], modes=[Phonon(energy=2 * np.pi * 1e6, eigenvector=[1, 0, 0])]
+    )
+    beam = Beam(
+        transition="q1->e0",
+        rabi=2 * np.pi * 1e6,
+        detuning=-2 * np.pi * 1.1e6,
+        phase=0,
+        polarization=[0, 0, 1],
+        wavevector=[1, 0, 0],
+        target=0,
+    )
+    protocol = SequentialProtocol(sequence=[Pulse(beam=beam, duration=1e-5)])
+    return ion, AtomicCircuit(system=system, protocol=protocol)
+
+
+def _run_qutip(circuit, ion, *, initial_state=None):
+    backend = QutipBackend(
+        approx_pass=_approx_pass(ion.levels),
+        solver_options={"progress_bar": False, "atol": 1e-10, "rtol": 1e-10},
+    )
+    experiment, hilbert_space = backend.compile(circuit, FOCK_CUTOFF)
+    return backend.run(
+        experiment,
+        hilbert_space=hilbert_space,
+        timestep=TIMESTEP,
+        initial_state=initial_state,
+    )
+
+
+def _run_dynamiqs(circuit, ion, *, initial_state=None, solver_options=None):
+    backend = DynamiqsBackend(
+        approx_pass=_approx_pass(ion.levels),
+        solver_options=solver_options or DynamiqsSolverOptions(rtol=1e-8, atol=1e-8),
+    )
+    experiment, hilbert_space = backend.compile(circuit, FOCK_CUTOFF)
+    result = backend.run(
+        experiment,
+        hilbert_space=hilbert_space,
+        timestep=TIMESTEP,
+        initial_state=initial_state,
+    )
+    return backend, experiment, hilbert_space, result
+
+
+def _qutip_populations(states):
+    return np.array([np.abs(s.full().flatten()) ** 2 for s in states])
+
+
+def _dynamiqs_populations(states):
+    return np.array([np.abs(np.asarray(s.to_jax()).flatten()) ** 2 for s in states])
+
+
+def _electronic_populations(pops, dim_e, dim_p):
+    return pops.reshape(pops.shape[0], dim_e, dim_p).sum(axis=2)
+
+
+class TestRabiSidebandParity:
+    """Dynamiqs reproduces the QuTiP reference on the example circuits."""
+
+    def test_microwave_rabi_carrier_parity(self):
+        ion, circuit = _microwave_circuit()
+
+        rq = _run_qutip(circuit, ion)
+        _, _, _, rd = _run_dynamiqs(circuit, ion)
+
+        pq = _qutip_populations(rq["states"])
+        pd = _dynamiqs_populations(rd["states"])
+
+        # identical save-time grid and number of saved states across backends
+        assert pq.shape == pd.shape
+        np.testing.assert_allclose(
+            np.array(rq["tspan"]), np.array(rd["tspan"]), atol=1e-15
+        )
+
+        # Dynamiqs reproduces QuTiP populations to a small tolerance
+        # observed agreement is ~1e-8 in double precision; 1e-5 keeps margin
+        np.testing.assert_allclose(pd, pq, atol=1e-5)
+
+        # probability is conserved
+        np.testing.assert_allclose(pd.sum(axis=1), 1.0, atol=1e-6)
+
+        # resonant carrier, one full period: invert to q1 at T/2, back to q0 at T
+        pe = _electronic_populations(pd, 2, 3)
+        assert pe[0, 0] > 0.99
+        assert pe[len(pe) // 2, 1] > 0.99
+        assert pe[-1, 0] > 0.99
+        np.testing.assert_allclose(pe, _electronic_populations(pq, 2, 3), atol=1e-5)
+
+    def test_red_sideband_parity(self):
+        ion, circuit = _red_sideband_circuit()
+        psi0_q = qt.tensor(qt.basis(2, 0), qt.basis(3, 1))
+        psi0_d = dq.tensor(dq.basis(2, 0), dq.basis(3, 1))
+
+        rq = _run_qutip(circuit, ion, initial_state=psi0_q)
+        _, _, _, rd = _run_dynamiqs(circuit, ion, initial_state=psi0_d)
+
+        pq = _qutip_populations(rq["states"])
+        pd = _dynamiqs_populations(rd["states"])
+
+        assert pq.shape == pd.shape
+        # observed agreement is ~1e-8 in double precision; 1e-5 keeps margin
+        np.testing.assert_allclose(pd, pq, atol=1e-5)
+        np.testing.assert_allclose(pd.sum(axis=1), 1.0, atol=1e-6)
+
+        # sideband transfers population from q1 into e0
+        pe = _electronic_populations(pd, 2, 3)
+        assert pe[0, 0] > 0.99  # starts in q1
+        assert pe[:, 1].max() > 0.1  # excited state e0 becomes populated
+
+    def test_hamiltonian_matches_qutip_at_gate_times(self):
+        ion, circuit = _microwave_circuit()
+        qb = QutipBackend(
+            approx_pass=_approx_pass(ion.levels),
+            solver_options={"progress_bar": False},
+        )
+        db = DynamiqsBackend(approx_pass=_approx_pass(ion.levels))
+        qexp, _ = qb.compile(circuit, FOCK_CUTOFF)
+        dexp, _ = db.compile(circuit, FOCK_CUTOFF)
+
+        hq = qexp.sequence[0].hamiltonian
+        hd = dexp.sequence[0].hamiltonian
+        for t in (0.0, 5e-7, 1e-6):
+            mq = hq(t).full()
+            md = np.asarray(hd(t).to_jax())
+            assert np.linalg.norm(md - mq) / max(np.linalg.norm(mq), 1.0) < 1e-6
+
+
+class TestDynamiqsJit:
+    """The Dynamiqs solve path is jax.jit-compatible and differentiable."""
+
+    def test_sesolve_path_is_jit_pure(self):
+        ion, circuit = _microwave_circuit()
+        backend = DynamiqsBackend(
+            approx_pass=_approx_pass(ion.levels),
+            solver_options=DynamiqsSolverOptions(rtol=1e-8, atol=1e-8),
+        )
+        experiment, hilbert_space = backend.compile(circuit, FOCK_CUTOFF)
+
+        hamiltonian = experiment.sequence[0].hamiltonian
+        method = backend.solver_options.to_method()
+        options = backend.solver_options.to_options()
+        tsave = jnp.linspace(0.0, 1e-6, 11)
+
+        @jax.jit
+        def evolve(psi0):
+            res = dq.sesolve(hamiltonian, psi0, tsave, method=method, options=options)
+            return res.final_state
+
+        psi0 = dq.tensor(
+            *[dq.basis(hilbert_space.size[k], 0) for k in hilbert_space.size.keys()]
+        )
+
+        # compiles + runs with no ConcretizationTypeError -> the solve is jit-pure
+        final = evolve(psi0)
+        arr = np.asarray(final.to_jax())
+        assert np.all(np.isfinite(arr))
+        np.testing.assert_allclose((np.abs(arr) ** 2).sum(), 1.0, atol=1e-6)
+
+    def test_sesolve_path_is_differentiable(self):
+        ion, circuit = _microwave_circuit()
+        backend = DynamiqsBackend(
+            approx_pass=_approx_pass(ion.levels),
+            solver_options=DynamiqsSolverOptions(rtol=1e-8, atol=1e-8),
+        )
+        experiment, hilbert_space = backend.compile(circuit, FOCK_CUTOFF)
+
+        hamiltonian = experiment.sequence[0].hamiltonian
+        method = backend.solver_options.to_method()
+        options = backend.solver_options.to_options()
+        tsave = jnp.linspace(0.0, 5e-7, 6)
+        phonon = dq.basis(3, 0)
+
+        def excited_population(theta):
+            elec = (
+                jnp.cos(theta) * dq.basis(2, 0).to_jax()
+                + jnp.sin(theta) * dq.basis(2, 1).to_jax()
+            )
+            psi0 = dq.tensor(dq.asqarray(elec), phonon)
+            res = dq.sesolve(
+                hamiltonian, psi0, tsave, method=method, options=options
+            )
+            return jnp.abs(res.final_state.to_jax().flatten()[3:6]).sum()
+
+        # End-to-end autodiff through the compiled Hamiltonian + sesolve.
+        grad = jax.grad(excited_population)(0.3)
+        assert np.isfinite(grad)
+        assert abs(grad) > 1e-3  # genuine dependence, not a zero/constant gradient
+
+
+class TestDynamiqsSolverOptions:
+    """Explicit, overridable Diffrax solver options."""
+
+    def test_defaults(self):
+        opts = DynamiqsSolverOptions()
+        assert opts.method == "Tsit5"
+        assert opts.rtol == 1e-8 and opts.atol == 1e-8
+        # progress meter off by default -> avoids the Jupyter ZMQError (#26)
+        assert opts.progress_meter is False
+        assert opts.to_options().progress_meter is False
+
+    def test_from_obj_normalizes_dict_and_none(self):
+        assert DynamiqsSolverOptions.from_obj(None) == DynamiqsSolverOptions()
+        assert DynamiqsSolverOptions.from_obj({"rtol": 1e-10}).rtol == 1e-10
+        passthrough = DynamiqsSolverOptions(atol=1e-9)
+        assert DynamiqsSolverOptions.from_obj(passthrough) is passthrough
+
+    def test_override_reaches_method(self):
+        opts = DynamiqsSolverOptions(method="Dopri5", rtol=1e-10, atol=1e-9)
+        method = opts.to_method()
+        assert method.rtol == 1e-10
+        assert method.atol == 1e-9
+
+
+class TestRunTask:
+    """run_task drives the backend from a validated Task (the TaskArgs path)."""
+
+    def test_task_args_emulator_is_a_validated_subclass(self):
+        # subclassing TaskArgsAtomic lets it ride the oqd-core Task.args union
+        # without Task.model_construct
+        _, circuit = _microwave_circuit()
+        args = TaskArgsAtomicEmulator(
+            fock_trunc=FOCK_CUTOFF,
+            dt=TIMESTEP,
+            solver_options=DynamiqsSolverOptions(rtol=1e-9),
+        )
+        assert isinstance(args, TaskArgsAtomic)
+        task = Task(program=circuit, args=args)
+        assert type(task.args) is TaskArgsAtomicEmulator
+        assert task.args.solver_options.rtol == 1e-9
+
+    def test_run_task_runs_the_rabi_flop(self):
+        ion, circuit = _microwave_circuit()
+        backend = DynamiqsBackend(approx_pass=_approx_pass(ion.levels))
+        args = TaskArgsAtomicEmulator(
+            fock_trunc=FOCK_CUTOFF,
+            dt=TIMESTEP,
+            solver_options=DynamiqsSolverOptions(rtol=1e-8, atol=1e-8),
+        )
+        result = backend.run_task(Task(program=circuit, args=args))
+
+        pe = _electronic_populations(_dynamiqs_populations(result["states"]), 2, 3)
+        assert pe[0, 0] > 0.99
+        assert pe[len(pe) // 2, 1] > 0.99
+        assert pe[-1, 0] > 0.99
+
+
+class TestEmptyGateTimeline:
+    """A pruned (empty) gate advances time monotonically without double-offset."""
+
+    def test_pruned_gate_timeline_is_monotonic(self):
+        from oqd_compiler_infrastructure import Pre
+
+        from oqd_trical.backend.dynamiqs.interface import (
+            DynamiqsExperiment,
+            DynamiqsGate,
+        )
+
+        hilbert_space = HilbertSpace(hilbert_space=dict(E0={0, 1}))
+        experiment = DynamiqsExperiment(
+            frame=None,
+            sequence=[
+                DynamiqsGate(hamiltonian=None, duration=1e-6),
+                DynamiqsGate(hamiltonian=None, duration=1e-6),
+            ],
+        )
+        vm = Pre(DynamiqsVM(hilbert_space=hilbert_space, timestep=TIMESTEP))
+        vm(experiment)
+        result = vm.children[0].result
+
+        tspan = np.array(result["tspan"])
+        assert np.all(np.diff(tspan) > 0)  # strictly increasing, no double-offset
+        np.testing.assert_allclose(tspan[-1], 2e-6, atol=1e-12)
+        assert len(result["states"]) == len(tspan)


### PR DESCRIPTION
● Fixes the Dynamiqs backend so it actually runs and matches QuTiP. The old code called dq.sesolve with solver=dq.solver.Tsit5(), but that kwarg and the dq.solver namespace don't exist in dynamiqs 0.3.2, so it just crashed. Switched to method=dq.method.Tsit5 with explicit dq.Options.

  Changes:
  - New DynamiqsSolverOptions (Tsit5, rtol=atol=1e-8), progress meter off by default which also fixes the Jupyter ZMQError in #26.
  - Save times are built host-side from duration/timestep, so nothing traced gets branched on and the solve is jit-able.
  - Added TaskArgsAtomicEmulator + run_task so solver options can go through a Task, like the analog emulator's QutipBackend.
  - Dropped a duplicate Hilbert-space pass, raise a real ValueError instead of a bare  string, and fixed the empty-gate timeline + initial_state check in both the Dynamiqs and QuTiP VMs.
  - Documented the rad/s + seconds units in code and docs.

  Fixes #43

  * **Please check if the PR fulfills these requirements**
  - [x] The commit message follows our guidelines
  - [x] Tests for the changes have been added (for bug fixes / features)
  - [x] Docs have been added / updated (for bug fixes / features)


  * **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  Mostly a bug fix, plus a small Task-based entry point and a docs update.


  * **What is the current behavior?** (You can also link to an open issue here)

  The backend crashes on any real run (#43) because of the bad sesolve call, and throws a ZMQError in Jupyter from the progress meter (#26). The existing tests only build the VMs, they never run a solve, so nothing was actually verified.


  * **What is the new behavior (if this is a feature change)?**

  It runs end to end and matches QuTiP to ~1e-8 on the Rabi carrier and red-sideband cases. Solver and tolerances are explicit and overridable (on the backend or via a Task), the progress meter is off by default, and the units are documented. Added parity, Hamiltonian-at-gate-time, jit and gradient tests.


  * **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

  No. The only change is the solver_options default going from {} to None (None just falls back to the defaults). The old {} couldn't run anyway, and passing a dict still works.


  * **Other information**:

  run_task and TaskArgsAtomicEmulator are additive, so compile/run are untouched and still mirror QutipBackend. TaskArgsAtomicEmulator subclasses oqd-core's TaskArgsAtomic so a normal Task validates it (no model_construct). map_OperatorMul is left as-is, the 1e-8 parity confirms it's already correct. ruff, copyright, pytest (13 passed, 2 xfailed) and mkdocs all pass locally.
