### PR TITLE
Fix #44: unitaryHACK 2026: Update `oqd-trical` Qutip backend to return a datast

### DIFF
--- a/docs/explanation/backends.md
+++ b/docs/explanation/backends.md
@@ -24,6 +24,26 @@ Compiles the AtomicCircuit into a compatible form for the backend to run on.
 
 Executes the compatible form of the AtomicCircuit with the backend using a tree walking interpreter.
 
+[`QutipBackend.run`][oqd_trical.backend.qutip.QutipBackend.run] returns an
+[`oqd_dataschema.Datastore`][oqd_dataschema.datastore.Datastore] containing a
+[`TrICalEmulatorDataGroup`][oqd_trical.backend.dataschema.TrICalEmulatorDataGroup]
+under the `emulation` key:
+
+```python
+import json
+
+backend = QutipBackend(approx_pass=approx_pass)
+experiment, hilbert_space = backend.compile(circuit, fock_cutoff=4)
+datastore = backend.run(experiment, hilbert_space, timestep=1e-7)
+
+datastore.model_dump_hdf5("trical_run.h5")
+
+sim = datastore.groups["emulation"]
+tspan = sim.tspan.data
+states = sim.states.data
+hilbert_dims = json.loads(sim.attrs["hilbert_space"])
+```
+
 <!-- prettier-ignore -->
 /// admonition | Examples
     type: example

--- a/src/oqd_trical/backend/dataschema.py
+++ b/src/oqd_trical/backend/dataschema.py
@@ -1,0 +1,91 @@
+# Copyright 2024-2025 Open Quantum Design
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any, Mapping
+
+import numpy as np
+import qutip as qt
+
+if not hasattr(np.dtypes, "StringDType"):
+    np.dtypes.StringDType = np.dtypes.StrDType
+
+from oqd_dataschema.dataset import Dataset
+from oqd_dataschema.datastore import Datastore
+from oqd_dataschema.group import GroupBase
+
+########################################################################################
+
+EMULATION_GROUP_KEY = "emulation"
+
+__all__ = [
+    "EMULATION_GROUP_KEY",
+    "TrICalEmulatorDataGroup",
+    "emulation_result_to_datastore",
+]
+
+
+class TrICalEmulatorDataGroup(GroupBase):
+    """Standard oqd-dataschema group for TrICal atomic emulator output."""
+
+    tspan: Dataset
+    states: Dataset
+    final_state: Dataset
+
+
+def _state_to_array(state: qt.Qobj) -> np.ndarray:
+    data = np.asarray(state.full())
+    if state.isoper:
+        return data
+    return data.reshape(-1)
+
+
+def _oqd_trical_version() -> str:
+    try:
+        return version("oqd-trical")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def emulation_result_to_datastore(
+    result: Mapping[str, Any],
+    *,
+    solver: str,
+    timestep: float,
+    backend: str = "qutip",
+) -> Datastore:
+    """Build a datastore from a QutipVM or DynamiqsVM result mapping."""
+    tspan = np.asarray(result["tspan"], dtype=float)
+    states = np.stack([_state_to_array(state) for state in result["states"]])
+    final_state = _state_to_array(result["final_state"])
+
+    hilbert_space = result["hilbert_space"]
+    frame = result.get("frame")
+
+    group = TrICalEmulatorDataGroup(
+        tspan=Dataset(data=tspan),
+        states=Dataset(data=states),
+        final_state=Dataset(data=final_state),
+        attrs={
+            "solver": solver,
+            "timestep": float(timestep),
+            "hilbert_space": json.dumps(hilbert_space.size),
+            "backend": backend,
+            "oqd_trical_version": _oqd_trical_version(),
+            "frame": "" if frame is None else str(frame),
+            "frame_is_none": int(frame is None),
+        },
+    )
+    return Datastore(groups={EMULATION_GROUP_KEY: group})

--- a/src/oqd_trical/backend/qutip/base.py
+++ b/src/oqd_trical/backend/qutip/base.py
@@ -17,6 +17,7 @@ from oqd_core.backend.base import BackendBase
 from oqd_core.compiler.atomic.canonicalize import canonicalize_atomic_circuit_factory
 from oqd_core.interface.atomic import AtomicCircuit
 
+from oqd_trical.backend.dataschema import emulation_result_to_datastore
 from oqd_trical.backend.qutip.codegen import QutipCodeGeneration
 from oqd_trical.backend.qutip.vm import QutipVM
 from oqd_trical.light_matter.compiler.analysis import GetHilbertSpace, HilbertSpace
@@ -127,7 +128,10 @@ class QutipBackend(BackendBase):
             timestep (float): Timestep between tracked states of the evolution.
 
         Returns:
-            result (Dict[str,Any]): Result of execution of [`QutipExperiment`][oqd_trical.backend.qutip.interface.QutipExperiment].
+            datastore (Datastore): Result of execution as an
+                [`oqd_dataschema.Datastore`][oqd_dataschema.datastore.Datastore]
+                with a single [`TrICalEmulatorDataGroup`][oqd_trical.backend.dataschema.TrICalEmulatorDataGroup]
+                under the `emulation` key.
         """
         vm = Pre(
             QutipVM(
@@ -141,4 +145,9 @@ class QutipBackend(BackendBase):
 
         vm(experiment)
 
-        return vm.children[0].result
+        return emulation_result_to_datastore(
+            vm.children[0].result,
+            solver=self.solver,
+            timestep=timestep,
+            backend="qutip",
+        )

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -13,10 +13,18 @@
 # limitations under the License.
 
 ########################################################################################
+import json
+from pathlib import Path
+
 import dynamiqs as dq
+import numpy as np
 import pytest
 import qutip as qt
 
+from oqd_trical.backend.dataschema import (
+    EMULATION_GROUP_KEY,
+    emulation_result_to_datastore,
+)
 from oqd_trical.backend.dynamiqs.vm import DynamiqsVM
 from oqd_trical.backend.qutip.vm import QutipVM
 from oqd_trical.light_matter.compiler.analysis import HilbertSpace
@@ -50,3 +58,49 @@ class TestInitialStateVM:
         initial_state = dq.tensor(dq.basis(2, 0), dq.basis(3, 0))
 
         DynamiqsVM(hilbert_space=hilbert_space, timestep=1, initial_state=initial_state)
+
+
+class TestEmulationDatastore:
+    def test_qutip_result_round_trip(self, tmp_path: Path):
+        hilbert_space = HilbertSpace(hilbert_space=dict(E0={0, 1}, E1={0, 1}))
+        initial_state = qt.tensor(qt.basis(2, 0), qt.basis(2, 0))
+        vm = QutipVM(
+            hilbert_space=hilbert_space,
+            timestep=1,
+            initial_state=initial_state,
+            solver_options={},
+        )
+        vm.frame = None
+
+        datastore = emulation_result_to_datastore(
+            vm.result,
+            solver="SESolver",
+            timestep=1.0,
+            backend="qutip",
+        )
+
+        sim = datastore.groups[EMULATION_GROUP_KEY]
+        assert sim.tspan.data.shape == (1,)
+        assert sim.states.data.shape == (1, 4)
+        assert sim.final_state.data.shape == (4,)
+        assert json.loads(sim.attrs["hilbert_space"]) == hilbert_space.size
+        assert sim.attrs["solver"] == "SESolver"
+        assert sim.attrs["timestep"] == 1.0
+
+        filepath = tmp_path / "trical_run.h5"
+        datastore.model_dump_hdf5(filepath)
+        loaded = datastore.model_validate_hdf5(filepath)
+
+        np.testing.assert_allclose(
+            loaded.groups[EMULATION_GROUP_KEY].tspan.data,
+            sim.tspan.data,
+        )
+        np.testing.assert_allclose(
+            loaded.groups[EMULATION_GROUP_KEY].states.data,
+            sim.states.data,
+        )
+        np.testing.assert_allclose(
+            loaded.groups[EMULATION_GROUP_KEY].final_state.data,
+            sim.final_state.data,
+        )
+        assert loaded.groups[EMULATION_GROUP_KEY].attrs == sim.attrs


### PR DESCRIPTION
Fixes #44

Updated `QutipBackend.run()` to return an `oqd_dataschema.Datastore` with a local `TrICalEmulatorDataGroup` (`tspan`, `states`, `final_state` datasets plus run metadata in `attrs` under the `emulation` key), documented the new API in `docs/explanation/backends.md`, and added an HDF5 round-trip test; `oqd-dataschema` is used as an existing dependency (not added to `pyproject.toml` per task constraints) and the upstream group contribution from the issue remains a separate follow-up.

Local tests pass.

---
This change was prepared with AI assistance under human direction and review.